### PR TITLE
fixed to show in actual order

### DIFF
--- a/packages/ui/src/Jantaku/JantakuCenter/index.tsx
+++ b/packages/ui/src/Jantaku/JantakuCenter/index.tsx
@@ -114,8 +114,7 @@ export const JantakuCenter = ({
           transformOrigin: 'top left',
         }}
       >
-        {getWind(orderedPlayerIDs[3], oya)}{' '}
-        {relativeScores[orderedPlayerIDs[3]]}点
+        {getWind(orderedPlayerIDs[3], oya)} {relativeScores[3]}点
       </Typography>
       {/* Toimen */}
       <Typography
@@ -137,8 +136,7 @@ export const JantakuCenter = ({
           transformOrigin: 'top right',
         }}
       >
-        {getWind(orderedPlayerIDs[2], oya)}{' '}
-        {relativeScores[orderedPlayerIDs[2]]}点
+        {getWind(orderedPlayerIDs[2], oya)} {relativeScores[2]}点
       </Typography>
       {/* Player */}
       <Typography
@@ -158,8 +156,7 @@ export const JantakuCenter = ({
           left: 0,
         }}
       >
-        {getWind(orderedPlayerIDs[0], oya)}{' '}
-        {relativeScores[orderedPlayerIDs[0]]}点
+        {getWind(orderedPlayerIDs[0], oya)} {relativeScores[0]}点
       </Typography>
       {/* Shimocha */}
       <Typography
@@ -181,8 +178,7 @@ export const JantakuCenter = ({
           transformOrigin: 'bottom right',
         }}
       >
-        {getWind(orderedPlayerIDs[1], oya)}{' '}
-        {relativeScores[orderedPlayerIDs[1]]}点
+        {getWind(orderedPlayerIDs[1], oya)} {relativeScores[1]}点
       </Typography>
     </Box>
   );


### PR DESCRIPTION
Just found out that there is an bug where when the player_id is not 0 the score on the jantaku center component will be wrong
This was because it was using the same logic as kawa. kawa is not ordered in any way and be in numeric order but in score it was showing the self score first then shimocha, toimen, kamicha. Reordering this caused the bug. Changed to show not reordering it. However reordering is  required to get the wind.